### PR TITLE
Fix register url in print_cost

### DIFF
--- a/src/python/ten/test/baserunner.py
+++ b/src/python/ten/test/baserunner.py
@@ -87,7 +87,7 @@ class TenRunnerPlugin():
                     web3 = Web3(Web3.HTTPProvider('%s/v1/?u=%s' % (gateway_url, user_id)))
                     runner.addCleanupFunction(lambda: self.__stop_process(hprocess))
                     runner.addCleanupFunction(lambda: self.__print_cost(runner,
-                                                                        '%s/v1/?u=%s' % (gateway_url, user_id),
+                                                                        '%s/v1/authenticate?u=%s' % (gateway_url, user_id),
                                                                         web3, user_id))
 
                 else:
@@ -101,7 +101,7 @@ class TenRunnerPlugin():
                     runner.log.info('Registration success was %s', response.ok)
                     web3 = Web3(Web3.HTTPProvider('%s/v1/?u=%s' % (gateway_url, user_id)))
                     runner.addCleanupFunction(lambda: self.__print_cost(runner,
-                                                                        '%s/v1/?u=%s' % (gateway_url, user_id),
+                                                                        '%s/v1/authenticate?u=%s' % (gateway_url, user_id),
                                                                         web3, user_id))
 
                 tx_count = web3.eth.get_transaction_count(account.address)


### PR DESCRIPTION
Currently we are sending authenticate request to `/v1` and not to `v1/authenticate`. 

It appeared in logs here: https://app.datadoghq.eu/logs?query=service%3Aobscuro_gateway_uat_testnet&cols=host%2Cservice&event=AgAAAYyL9GsTbxDTQgAAAAAAAAAYAAAAAEFZeUw5SENXQUFDNkpXRHd3XzdzUGdBSwAAACQAAAAAMDE4YzhiZjUtYmU0My00MTgwLWExMTUtY2QxZDIyODU4YTk5&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&viz=stream&from_ts=1703143424387&to_ts=1703157824387&live=true
