### PR TITLE
skip per_008

### DIFF
--- a/tests/ten/ten_per_008/pysystest.xml
+++ b/tests/ten/ten_per_008/pysystest.xml
@@ -13,6 +13,7 @@ throughput and the bulk throughput across all clients.
     <classification>
         <groups inherit="true">
             <group>performance</group>
+            <group>skip</group>
         </groups>
         <modes inherit="true">
             <mode>ten.sepolia</mode>


### PR DESCRIPTION
It fails with an error that looks unrelated to the test:

```2024-03-26 13:29:04,616 WARN  caught <class 'TypeError'> while running test: expected non-empty vector for x
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/pysys/baserunner.py", line 1164, in __call__
    self.testObj.execute()
  File "/home/tenadmin/actions-runner/_work/ten-test/ten-test/ten-test/tests/ten/ten_per_008/run.py", line 34, in execute
    throughput = self.process_throughput(clients, out_dir, start_ns, end_ns)
  File "/home/tenadmin/actions-runner/_work/ten-test/ten-test/ten-test/tests/ten/ten_per_008/run.py", line 105, in process_throughput
    throughput = self.find_best_fit(bins_steady)
  File "/home/tenadmin/actions-runner/_work/ten-test/ten-test/ten-test/tests/ten/ten_per_008/run.py", line 155, in find_best_fit
    coeffs = np.polyfit(x_values, y_values, deg=0)
  File "<__array_function__ internals>", line 200, in polyfit
  File "/home/tenadmin/.local/lib/python3.8/site-packages/numpy/lib/polynomial.py", line 638, in polyfit
    raise TypeError("expected non-empty vector for x")
TypeError: expected non-empty vector for x
2024-03-26 13:29:04,618 WARN  TypeError: expected non-empty vector for x ... blocked 
```