### PR TITLE
Fix off by one error in ten_cor_161 and ten_cor_153

### DIFF
--- a/tests/ten/ten_cor_153/run.py
+++ b/tests/ten/ten_cor_153/run.py
@@ -45,7 +45,7 @@ class PySysTest(TenNetworkTest):
                 reported_total = r['Total']
 
                 for block in r['BatchesData']:
-                    numbers.append(int(block['header']['number'], 16))
+                    numbers.append(int(block['header']['sequencerOrderNo'], 16))
                     if block['header']['hash'] == tx_block_hash:
                         self.log.info('    Block found in offset call %d', offset)
                         found_block = True

--- a/tests/ten/ten_cor_161/run.py
+++ b/tests/ten/ten_cor_161/run.py
@@ -7,11 +7,12 @@ from ten.test.contracts.storage import Storage
 class PySysTest(TenNetworkTest):
 
     def execute(self):
-        # get the latest rollup and from that the first and last batch sequence numbers
+         # get the latest rollup and from that the first and last batch sequence numbers
         rollup_header = self.scan_get_latest_rollup_header()
         first = int(rollup_header['FirstBatchSeqNo'])
         last = int(rollup_header['LastBatchSeqNo'])
-        total = last - first
+        # the range is inclusive 
+        total = last - first + 1 
         self.log.info('First and last batch seq nos are %d %d, total %d', first, last, total)
 
         batches = []
@@ -20,7 +21,7 @@ class PySysTest(TenNetworkTest):
             batches.extend(self.scan_get_rollup_batches(hash=rollup_header['hash'], offset=page[0], size=page[1])['BatchesData'])
 
         self.assertTrue(len(batches) <= total, assertMessage='Batches should be less than or equal to the page size')
-        batch_nos = [int(x['header']['number'], 16) for x in batches]
+        batch_nos = [int(x['header']['sequencerOrderNo'], 16) for x in batches]
         self.log.info('Batch numbers are %s', batch_nos)
         self.assertTrue(batch_nos[0] == last, assertMessage='Last batch should be in the return set')
         self.assertTrue(batch_nos[-1] == first, assertMessage='First batch should be in the return set')


### PR DESCRIPTION
**ten_cor_161**
The range returned by `scan_getRollupBatches` is inclusive so the total needs to be `last - first + 1` and we were getting the batch height, not the batch sequence number from the returned results. 

**ten_cor_153**
We were seeing duplciate numbers because it was batch height, not sequence number. 

Note: this is dependent on this PR in go-ten repo https://github.com/ten-protocol/go-ten/pull/2584